### PR TITLE
removed SRTM dependency, instead using NASADEM via CTF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = ['numpy',
                 'pyproj',
                 'geojson',
                 'rasterio[s3]>=1.2',
-                'srtm4>=1.0.2']
+                'hydrosat-cirrustask @ git+ssh://git@github.com/Hydrosat/cirrus-task-framework.git@0.18.8']
 
 extras_require = {'test': ['pytest']}
 


### PR DESCRIPTION
i checked one of the CLI localization examples which pulls an elevation value based on LON/LAT coordinates, and it runs without error. Note that it may be better to associate the requirement in `setup.py`:

```
hydrosat-cirrustask @ git+ssh://git@github.com/Hydrosat/cirrus-task-framework.git@0.18.8
```
with `@latest` or similar if that is possible, so we don't have to constantly update the `setup.py` file every time CTF is updated. thoughts? @imcgreer @hydrosat-dgleason @garnyt @zzyydtc 

Also, this is not time sensitive since the tests in branches where we saw build errors occur are no longer breaking. 

lastly, I tested this in an environment that did not have `rpcm` installed, and installed using `pip install -e .` from the `rpcm` directory.